### PR TITLE
fix(frontend): delete node/site has immediate visual effect on canvas

### DIFF
--- a/frontend/src/components/GraphBuilder/PropertiesPanel.tsx
+++ b/frontend/src/components/GraphBuilder/PropertiesPanel.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useReactFlow } from 'reactflow';
 import { useGraphStore } from '../../hooks/useGraphStore';
 import type { NodeData } from '../../types/nodeData';
 
@@ -34,20 +33,7 @@ const inputCls =
   'w-full text-sm border border-gray-200 rounded px-2.5 py-1.5 focus:outline-none focus:ring-2 focus:ring-indigo-300 focus:border-indigo-400 transition';
 
 export const PropertiesPanel: React.FC = () => {
-  const { nodes, edges, selectedNodeId, selectedEdgeId, updateNodeData, updateEdge, deleteEdge, onNodesChange, onEdgesChange } = useGraphStore();
-
-  const { setNodes } = useReactFlow();
-
-  const handleDeleteNode = (nodeId: string) => {
-    const childIds = nodes
-      .filter((n) => (n as any).parentNode === nodeId)
-      .map((n) => n.id);
-    const allIds = [nodeId, ...childIds];
-    const remaining = nodes.filter((n) => !allIds.includes(n.id));
-    // Update both Zustand store and ReactFlow internal nodeInternals in the same cycle
-    onNodesChange(allIds.map((id) => ({ type: 'remove' as const, id })));
-    setNodes(remaining);
-  };
+  const { nodes, edges, selectedNodeId, selectedEdgeId, updateNodeData, updateEdge, deleteEdge, deleteNode } = useGraphStore();
 
   const selectedNode = selectedNodeId
     ? nodes.find((n) => n.id === selectedNodeId) ?? null
@@ -308,7 +294,7 @@ export const PropertiesPanel: React.FC = () => {
       <div className="pt-4 border-t border-gray-100 mt-4">
         <button
           className="w-full text-sm font-semibold text-red-600 border border-red-200 bg-red-50 hover:bg-red-100 rounded px-3 py-2 transition-colors"
-          onClick={() => handleDeleteNode(selectedNode.id)}
+          onClick={() => deleteNode(selectedNode.id)}
         >
           {nodeType === 'siteGroup' ? 'Eliminar sede y sus equipos' : 'Eliminar nodo'}
         </button>

--- a/frontend/src/test/components/PropertiesPanel.test.tsx
+++ b/frontend/src/test/components/PropertiesPanel.test.tsx
@@ -1,13 +1,14 @@
 /**
- * TASK 5.1 RED — PropertiesPanel tests
+ * PropertiesPanel tests
  *
  * Tests:
  * S4: edge panel shows a <select> with 4 options: fiber/mpls/sdwan/aviat
  * S5: changing the edge type select calls updateEdge
  * S6: siteGroup panel shows aviat_carrier in the wan_type select
+ * S7: clicking "Eliminar nodo" calls deleteNode with the node id
+ * S8: clicking "Eliminar sede y sus equipos" calls deleteNode with the site group id
  */
 
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { act } from '@testing-library/react'
@@ -100,5 +101,52 @@ describe('PropertiesPanel siteGroup panel', () => {
     const select = screen.getByRole('combobox', { name: /tipo wan/i })
     const options = Array.from(select.querySelectorAll('option')).map((o) => (o as HTMLOptionElement).value)
     expect(options).toContain('aviat_carrier')
+  })
+})
+
+// ── Delete node tests ─────────────────────────────────────────────────────────
+
+const REGULAR_NODE = {
+  id: 'n1',
+  type: 'coreInternal',
+  position: { x: 0, y: 0 },
+  data: { label: 'Core INT', observable: true },
+}
+
+describe('PropertiesPanel delete', () => {
+  it('S7: clicking "Eliminar nodo" calls deleteNode with the node id', () => {
+    const deleteNodeSpy = vi.fn()
+    act(() => {
+      useGraphStore.setState({
+        nodes: [REGULAR_NODE as any],
+        edges: [],
+        selectedNodeId: 'n1',
+        selectedEdgeId: null,
+        deleteNode: deleteNodeSpy,
+      } as any)
+    })
+
+    render(<PropertiesPanel />)
+    const btn = screen.getByRole('button', { name: /eliminar nodo/i })
+    fireEvent.click(btn)
+    expect(deleteNodeSpy).toHaveBeenCalledWith('n1')
+  })
+
+  it('S8: clicking "Eliminar sede y sus equipos" calls deleteNode with the site group id', () => {
+    const deleteNodeSpy = vi.fn()
+    act(() => {
+      useGraphStore.setState({
+        nodes: [SITE_NODE as any],
+        edges: [],
+        selectedNodeId: 'site-1',
+        selectedEdgeId: null,
+        deleteNode: deleteNodeSpy,
+      } as any)
+    })
+
+    render(<PropertiesPanel />)
+    const btn = screen.getByRole('button', { name: /eliminar sede/i })
+    fireEvent.click(btn)
+    expect(deleteNodeSpy).toHaveBeenCalledWith('site-1')
   })
 })


### PR DESCRIPTION
## Summary

Fixes #1 — clicking **Eliminar nodo** or **Eliminar sede y sus equipos** now immediately removes the node/site from the ReactFlow canvas without requiring a full page refresh.

## Root Cause

PropertiesPanel had a duplicate handleDeleteNode that wrote to **two stores simultaneously**:
- onNodesChange() → Zustand (external store)  
- setNodes() from useReactFlow() → ReactFlow internal store

In ReactFlow v11 **controlled mode**, the 
odes prop from Zustand is the single source of truth. On the next render, ReactFlow's useStoreUpdater re-syncs 
odeInternals from the Zustand 
odes prop — overwriting the setNodes() call. Result: the canvas never updated visually.

## Fix

Removed handleDeleteNode entirely. The store already has a correct deleteNode action that uses pplyNodeChanges with {type: 'remove'} changes — the one-writer pattern required by ReactFlow v11 controlled mode.

## Changes

- rontend/src/components/GraphBuilder/PropertiesPanel.tsx — removed handleDeleteNode, useReactFlow import, setNodes, and (n as any) cast; wired delete button to deleteNode from store
- rontend/src/test/components/PropertiesPanel.test.tsx — added S7 and S8 tests for delete behavior

## Test Results

- tsc: 0 errors  
- vitest: 47/47 passed (+2 new tests)