### PR TITLE
fix(graph): persist node/site deletions to backend

### DIFF
--- a/backend/routers/graph.py
+++ b/backend/routers/graph.py
@@ -48,8 +48,34 @@ async def upsert_topology(
     payload: TopologyGraphSchema,
     db: AsyncSession = Depends(get_db),
 ):
-    """Upsert all sites, nodes, and edges from the payload."""
+    """Replace the full topology with the payload (insert/update + delete orphans)."""
     try:
+        incoming_site_ids = {s.id for s in payload.sites}
+        incoming_node_ids = {n.id for n in payload.nodes}
+        incoming_edge_ids = {e.id for e in payload.edges}
+
+        # ── Delete orphans (rows in DB not present in payload) ────────────────
+
+        existing_sites = (await db.execute(select(Site))).scalars().all()
+        for site in existing_sites:
+            if site.id not in incoming_site_ids:
+                await db.delete(site)
+
+        existing_nodes = (await db.execute(select(NetworkNode))).scalars().all()
+        for node in existing_nodes:
+            if node.id not in incoming_node_ids:
+                await db.delete(node)
+
+        existing_edges = (await db.execute(select(NetworkEdge))).scalars().all()
+        for edge in existing_edges:
+            if edge.id not in incoming_edge_ids:
+                await db.delete(edge)
+
+        # Flush deletes before upserts to avoid FK constraint violations
+        await db.flush()
+
+        # ── Upsert what remains in the payload ───────────────────────────────
+
         # Sites
         for site_data in payload.sites:
             existing = await db.get(Site, site_data.id)
@@ -58,6 +84,10 @@ async def upsert_topology(
                 existing.role = site_data.role
                 existing.wan_type = site_data.wan_type
                 existing.observable_boundary = site_data.observable_boundary
+                existing.canvas_x = site_data.canvas_x
+                existing.canvas_y = site_data.canvas_y
+                existing.canvas_w = site_data.canvas_w
+                existing.canvas_h = site_data.canvas_h
             else:
                 db.add(Site(**site_data.model_dump(exclude_none=False)))
 

--- a/frontend/src/api/graph.ts
+++ b/frontend/src/api/graph.ts
@@ -1,5 +1,51 @@
 import apiClient from './client';
+import type { Node, Edge } from 'reactflow';
 import type { TopologyGraphSchema } from '../types/api';
+
+// ── Payload builder (pure) ────────────────────────────────────────────────────
+// Shared by GraphCanvas (manual save) and PropertiesPanel (auto-save on delete).
+
+export function buildSavePayload(nodes: Node[], edges: Edge[]): TopologyGraphSchema {
+  const siteNodes = nodes.filter((n) => n.type === 'siteGroup');
+  const regularNodes = nodes.filter((n) => n.type !== 'siteGroup');
+  return {
+    sites: siteNodes.map((n) => ({
+      id: n.id,
+      name: n.data?.label ?? n.id,
+      role: n.data?.role ?? 'spoke',
+      wan_type: n.data?.wan_type ?? 'mpls_aviat',
+      observable_boundary: n.data?.observable_boundary ?? null,
+      canvas_x: n.position.x,
+      canvas_y: n.position.y,
+      canvas_w: (n.style?.width as number) ?? 400,
+      canvas_h: (n.style?.height as number) ?? 300,
+    })),
+    nodes: regularNodes.map((n) => ({
+      id: n.id,
+      site_id: (n as any).parentNode ?? n.data?.siteId ?? '',
+      label: n.data?.label ?? n.id,
+      node_type: n.type ?? 'access_switch',
+      vendor: n.data?.vendor ?? 'Cisco',
+      management_ip: n.data?.management_ip ?? null,
+      role: n.data?.role ?? null,
+      zone: n.data?.zone ?? null,
+      observable: n.data?.observable ?? true,
+      position_x: n.position.x,
+      position_y: n.position.y,
+      meta: {},
+    })),
+    edges: edges.map((e) => ({
+      id: e.id,
+      source_id: e.source,
+      target_id: e.target,
+      edge_type: e.type ?? 'fiber',
+      vrf: e.data?.vrf ?? null,
+      capacity_mbps: e.data?.capacity_mbps ?? null,
+    })),
+  };
+}
+
+// ── API calls ─────────────────────────────────────────────────────────────────
 
 export const getGraph = async (): Promise<TopologyGraphSchema> => {
   const res = await apiClient.get<TopologyGraphSchema>('/api/graph/');

--- a/frontend/src/components/GraphBuilder/GraphCanvas.tsx
+++ b/frontend/src/components/GraphBuilder/GraphCanvas.tsx
@@ -11,7 +11,7 @@ import type { NodeTypes, EdgeTypes } from 'reactflow';
 import 'reactflow/dist/style.css';
 
 import { useGraphStore } from '../../hooks/useGraphStore';
-import { getGraph, saveGraph, exportGraph } from '../../api/graph';
+import { getGraph, saveGraph, exportGraph, buildSavePayload } from '../../api/graph';
 
 import { CoreInternalNode } from './nodes/CoreInternalNode';
 import { CoreExternalNode } from './nodes/CoreExternalNode';
@@ -52,7 +52,7 @@ const edgeTypes: EdgeTypes = {
 
 const GraphCanvasInternal: React.FC = () => {
   const reactFlowWrapper = useRef<HTMLDivElement>(null);
-  const { nodes, edges, onNodesChange, onEdgesChange, onConnect, addNode, selectNode, selectEdge, setGraph } =
+  const { nodes, edges, onNodesChange, onEdgesChange, onConnect, addNode, selectNode, selectEdge, setGraph, isDirty, markSaved } =
     useGraphStore();
   const { screenToFlowPosition } = useReactFlow();
 
@@ -179,55 +179,15 @@ const GraphCanvasInternal: React.FC = () => {
     setSaveError(null);
     try {
       const { nodes: rfNodes, edges: rfEdges } = useGraphStore.getState();
-
-      const siteNodes = rfNodes.filter((n) => n.type === 'siteGroup');
-      const regularNodes = rfNodes.filter((n) => n.type !== 'siteGroup');
-
-      // Convert ReactFlow nodes/edges to TopologyGraphSchema for the API
-      const payload = {
-        sites: siteNodes.map((n) => ({
-          id: n.id,
-          name: n.data?.label ?? n.id,
-          role: n.data?.role ?? 'spoke',
-          wan_type: n.data?.wan_type ?? 'mpls_aviat',
-          observable_boundary: n.data?.observable_boundary ?? null,
-          canvas_x: n.position.x,
-          canvas_y: n.position.y,
-          canvas_w: (n.style?.width as number) ?? 400,
-          canvas_h: (n.style?.height as number) ?? 300,
-        })),
-        nodes: regularNodes.map((n) => ({
-          id: n.id,
-          // ReactFlow v11 stores the parent group id in parentNode (runtime property)
-          site_id: (n as any).parentNode ?? n.data?.siteId ?? '',
-          label: n.data?.label ?? n.id,
-          node_type: n.type ?? 'access_switch',
-          vendor: n.data?.vendor ?? 'Cisco',
-          management_ip: n.data?.management_ip ?? null,
-          role: n.data?.role ?? null,
-          zone: n.data?.zone ?? null,
-          observable: n.data?.observable ?? true,
-          position_x: n.position.x,
-          position_y: n.position.y,
-          meta: {},
-        })),
-        edges: rfEdges.map((e) => ({
-          id: e.id,
-          source_id: e.source,
-          target_id: e.target,
-          edge_type: e.type ?? 'fiber',
-          vrf: e.data?.vrf ?? null,
-          capacity_mbps: e.data?.capacity_mbps ?? null,
-        })),
-      };
-      await saveGraph(payload);
+      await saveGraph(buildSavePayload(rfNodes, rfEdges));
+      markSaved();
     } catch (err) {
       setSaveError('Error al guardar. Revisa la conexión con el servidor.');
       console.error(err);
     } finally {
       setSaving(false);
     }
-  }, []);
+  }, [markSaved]);
 
   // ── Validate ─────────────────────────────────────────────────────────────
 
@@ -236,6 +196,18 @@ const GraphCanvasInternal: React.FC = () => {
     const results = runValidation(n, e);
     setValidationResults(results);
   }, []);
+
+  // ── Dirty state — warn on unload ──────────────────────────────────────────
+
+  useEffect(() => {
+    if (!isDirty) return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = '';
+    };
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [isDirty]);
 
   return (
     <div className="relative w-full h-full" ref={reactFlowWrapper}>
@@ -259,6 +231,12 @@ const GraphCanvasInternal: React.FC = () => {
           )}
           Guardar
         </button>
+
+        {isDirty && (
+          <span className="text-xs font-medium text-amber-500 flex items-center gap-1" title="Hay cambios sin guardar">
+            ● sin guardar
+          </span>
+        )}
 
         <div className="w-px h-5 bg-gray-200" />
 

--- a/frontend/src/components/GraphBuilder/PropertiesPanel.tsx
+++ b/frontend/src/components/GraphBuilder/PropertiesPanel.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useGraphStore } from '../../hooks/useGraphStore';
+import { saveGraph, buildSavePayload } from '../../api/graph';
 import type { NodeData } from '../../types/nodeData';
 
 const IP_REGEX = /^(\d{1,3}\.){3}\d{1,3}(\/\d{1,2})?$/;
@@ -33,7 +35,27 @@ const inputCls =
   'w-full text-sm border border-gray-200 rounded px-2.5 py-1.5 focus:outline-none focus:ring-2 focus:ring-indigo-300 focus:border-indigo-400 transition';
 
 export const PropertiesPanel: React.FC = () => {
-  const { nodes, edges, selectedNodeId, selectedEdgeId, updateNodeData, updateEdge, deleteEdge, deleteNode } = useGraphStore();
+  const { nodes, edges, selectedNodeId, selectedEdgeId, updateNodeData, updateEdge, deleteEdge, deleteNode, markSaved } = useGraphStore();
+  const [autoSaveError, setAutoSaveError] = useState<string | null>(null);
+  const [confirmPending, setConfirmPending] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  // ── Execute confirmed delete + auto-save ──────────────────────────────────
+  const executeDelete = async (nodeId: string) => {
+    setDeleting(true);
+    setAutoSaveError(null);
+    deleteNode(nodeId);
+    try {
+      const { nodes: n, edges: e } = useGraphStore.getState();
+      await saveGraph(buildSavePayload(n, e));
+      markSaved();
+    } catch {
+      setAutoSaveError('Error al guardar. Revisa la conexión.');
+    } finally {
+      setDeleting(false);
+      setConfirmPending(false);
+    }
+  };
 
   const selectedNode = selectedNodeId
     ? nodes.find((n) => n.id === selectedNodeId) ?? null
@@ -294,11 +316,70 @@ export const PropertiesPanel: React.FC = () => {
       <div className="pt-4 border-t border-gray-100 mt-4">
         <button
           className="w-full text-sm font-semibold text-red-600 border border-red-200 bg-red-50 hover:bg-red-100 rounded px-3 py-2 transition-colors"
-          onClick={() => deleteNode(selectedNode.id)}
+          onClick={() => setConfirmPending(true)}
         >
           {nodeType === 'siteGroup' ? 'Eliminar sede y sus equipos' : 'Eliminar nodo'}
         </button>
+        {autoSaveError && (
+          <p className="text-xs text-red-500 mt-1 text-center">{autoSaveError}</p>
+        )}
       </div>
+
+      {/* ── Confirmation modal (rendered via portal to escape overflow-hidden) ─ */}
+      {confirmPending && createPortal(
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="confirm-delete-title"
+          className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50 backdrop-blur-[2px]"
+          onClick={(e) => { if (e.target === e.currentTarget) setConfirmPending(false); }}
+        >
+          <div className="bg-white rounded-xl shadow-2xl w-80 p-6 flex flex-col gap-5 border border-gray-100">
+            {/* Icon */}
+            <div className="flex items-center justify-center w-12 h-12 rounded-full bg-red-50 mx-auto">
+              <svg className="w-6 h-6 text-red-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+                <path d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6" />
+                <path d="M10 11v6M14 11v6" />
+              </svg>
+            </div>
+            {/* Title + body */}
+            <div className="text-center">
+              <h3 id="confirm-delete-title" className="text-sm font-bold text-gray-900">
+                {nodeType === 'siteGroup' ? '¿Eliminar sede?' : '¿Eliminar nodo?'}
+              </h3>
+              <p className="text-xs text-gray-500 mt-2 leading-relaxed">
+                {nodeType === 'siteGroup'
+                  ? <>Se eliminarán <strong>la sede y todos sus equipos</strong>.<br />Esta acción se guarda automáticamente y <strong>no se puede deshacer</strong>.</>
+                  : <>Se eliminará <strong>{selectedNode.data?.label || selectedNode.id}</strong>.<br />Esta acción se guarda automáticamente y <strong>no se puede deshacer</strong>.</>
+                }
+              </p>
+            </div>
+            {/* Actions */}
+            <div className="flex gap-2">
+              <button
+                className="flex-1 text-sm font-medium text-gray-700 border border-gray-200 bg-white hover:bg-gray-50 rounded-lg px-3 py-2 transition-colors"
+                onClick={() => setConfirmPending(false)}
+                disabled={deleting}
+              >
+                Cancelar
+              </button>
+              <button
+                className="flex-1 text-sm font-semibold text-white bg-red-500 hover:bg-red-600 disabled:opacity-60 rounded-lg px-3 py-2 transition-colors flex items-center justify-center gap-1.5"
+                onClick={() => executeDelete(selectedNode.id)}
+                disabled={deleting}
+              >
+                {deleting && (
+                  <svg className="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+                    <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4" />
+                  </svg>
+                )}
+                {deleting ? 'Eliminando…' : 'Sí, eliminar'}
+              </button>
+            </div>
+          </div>
+        </div>,
+        document.body
+      )}
     </div>
   );
 };

--- a/frontend/src/hooks/useGraphStore.ts
+++ b/frontend/src/hooks/useGraphStore.ts
@@ -21,6 +21,9 @@ interface GraphState {
   selectedNodeId: string | null;
   selectedEdgeId: string | null;
 
+  // Dirty state — true when there are unsaved mutations
+  isDirty: boolean;
+
   // ReactFlow change handlers
   onNodesChange: OnNodesChange;
   onEdgesChange: OnEdgesChange;
@@ -38,6 +41,9 @@ interface GraphState {
   setGraph: (nodes: Node[], edges: Edge[]) => void;
   addNode: (node: Node) => void;
 
+  // Persistence
+  markSaved: () => void;
+
   // Legacy helpers kept for backward compatibility
   setNodes: (nodes: Node[]) => void;
   setEdges: (edges: Edge[]) => void;
@@ -49,6 +55,7 @@ export const useGraphStore = create<GraphState>((set, get) => ({
   edges: [],
   selectedNodeId: null,
   selectedEdgeId: null,
+  isDirty: false,
 
   // ── ReactFlow change handlers ────────────────────────────────────────────
 
@@ -93,6 +100,7 @@ export const useGraphStore = create<GraphState>((set, get) => ({
 
   updateNodeData: (id, patch) =>
     set({
+      isDirty: true,
       nodes: get().nodes.map((n) =>
         n.id === id ? { ...n, data: { ...n.data, ...patch } } : n,
       ),
@@ -100,6 +108,7 @@ export const useGraphStore = create<GraphState>((set, get) => ({
 
   updateEdge: (id, patch) =>
     set({
+      isDirty: true,
       edges: get().edges.map((e) =>
         e.id === id ? { ...e, ...patch } : e,
       ),
@@ -118,6 +127,7 @@ export const useGraphStore = create<GraphState>((set, get) => ({
     const updatedNodes = applyNodeChanges(removeChanges, get().nodes);
 
     set({
+      isDirty: true,
       nodes: updatedNodes,
       edges: get().edges.filter((e) => !allIds.includes(e.source) && !allIds.includes(e.target)),
       selectedNodeId: allIds.includes(get().selectedNodeId ?? '') ? null : get().selectedNodeId,
@@ -128,6 +138,7 @@ export const useGraphStore = create<GraphState>((set, get) => ({
     // Use applyEdgeChanges so ReactFlow's internal state stays in sync.
     const updatedEdges = applyEdgeChanges([{ type: 'remove', id }], get().edges);
     set({
+      isDirty: true,
       edges: updatedEdges,
       selectedEdgeId: get().selectedEdgeId === id ? null : get().selectedEdgeId,
     });
@@ -135,7 +146,9 @@ export const useGraphStore = create<GraphState>((set, get) => ({
 
   setGraph: (nodes, edges) => set({ nodes, edges }),
 
-  addNode: (node) => set({ nodes: [...get().nodes, node] }),
+  addNode: (node) => set({ isDirty: true, nodes: [...get().nodes, node] }),
+
+  markSaved: () => set({ isDirty: false }),
 
   // ── Legacy helpers ────────────────────────────────────────────────────────
 

--- a/frontend/src/test/components/GraphCanvas.serialization.test.tsx
+++ b/frontend/src/test/components/GraphCanvas.serialization.test.tsx
@@ -15,13 +15,18 @@ import { act } from '@testing-library/react'
 import { useGraphStore } from '../../hooks/useGraphStore'
 
 // ── Mock the API module so saveGraph doesn't make real HTTP calls ─────────────
-vi.mock('../../api/graph', () => ({
-  saveGraph: vi.fn().mockResolvedValue(undefined),
-  getGraph: vi.fn().mockResolvedValue({ sites: [], nodes: [], edges: [] }),
-  updateNode: vi.fn().mockResolvedValue(undefined),
-  deleteNode: vi.fn().mockResolvedValue(undefined),
-  exportGraph: vi.fn().mockResolvedValue({}),
-}))
+vi.mock('../../api/graph', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../api/graph')>()
+  return {
+    ...actual,
+    // Keep buildSavePayload real so payload assertions work
+    saveGraph: vi.fn().mockResolvedValue(undefined),
+    getGraph: vi.fn().mockResolvedValue({ sites: [], nodes: [], edges: [] }),
+    updateNode: vi.fn().mockResolvedValue(undefined),
+    deleteNode: vi.fn().mockResolvedValue(undefined),
+    exportGraph: vi.fn().mockResolvedValue({}),
+  }
+})
 
 // ── Mock ReactFlow internals to avoid ResizeObserver / canvas issues ──────────
 vi.mock('reactflow', async (importOriginal) => {

--- a/frontend/src/test/components/PropertiesPanel.test.tsx
+++ b/frontend/src/test/components/PropertiesPanel.test.tsx
@@ -7,12 +7,20 @@
  * S6: siteGroup panel shows aviat_carrier in the wan_type select
  * S7: clicking "Eliminar nodo" calls deleteNode with the node id
  * S8: clicking "Eliminar sede y sus equipos" calls deleteNode with the site group id
+ * S9: clicking "Eliminar nodo" calls saveGraph (auto-save)
+ * S10: clicking "Eliminar sede..." calls saveGraph (auto-save)
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { act } from '@testing-library/react'
 import { useGraphStore } from '../../hooks/useGraphStore'
+
+const mockSaveGraph = vi.fn().mockResolvedValue(undefined)
+vi.mock('../../api/graph', () => ({
+  saveGraph: (...args: unknown[]) => mockSaveGraph(...args),
+  buildSavePayload: vi.fn().mockReturnValue({ sites: [], nodes: [], edges: [] }),
+}))
 
 // ── Minimal reactflow mock ────────────────────────────────────────────────────
 vi.mock('reactflow', async (importOriginal) => {
@@ -114,7 +122,32 @@ const REGULAR_NODE = {
 }
 
 describe('PropertiesPanel delete', () => {
-  it('S7: clicking "Eliminar nodo" calls deleteNode with the node id', () => {
+  it('S7: clicking "Eliminar nodo" opens confirmation modal, then deleteNode is called on confirm', async () => {
+    const deleteNodeSpy = vi.fn()
+    act(() => {
+      useGraphStore.setState({
+        nodes: [REGULAR_NODE as any],
+        edges: [],
+        selectedNodeId: 'n1',
+        selectedEdgeId: null,
+        deleteNode: deleteNodeSpy,
+        markSaved: vi.fn(),
+      } as any)
+    })
+
+    render(<PropertiesPanel />)
+    // First click opens the modal — deleteNode NOT called yet
+    const btn = screen.getByRole('button', { name: /eliminar nodo/i })
+    fireEvent.click(btn)
+    expect(deleteNodeSpy).not.toHaveBeenCalled()
+
+    // Modal appears with confirm button
+    const confirmBtn = await screen.findByRole('button', { name: /sí, eliminar/i })
+    fireEvent.click(confirmBtn)
+    await waitFor(() => expect(deleteNodeSpy).toHaveBeenCalledWith('n1'))
+  })
+
+  it('S7b: clicking "Cancelar" in modal does NOT call deleteNode', async () => {
     const deleteNodeSpy = vi.fn()
     act(() => {
       useGraphStore.setState({
@@ -127,12 +160,13 @@ describe('PropertiesPanel delete', () => {
     })
 
     render(<PropertiesPanel />)
-    const btn = screen.getByRole('button', { name: /eliminar nodo/i })
-    fireEvent.click(btn)
-    expect(deleteNodeSpy).toHaveBeenCalledWith('n1')
+    fireEvent.click(screen.getByRole('button', { name: /eliminar nodo/i }))
+    const cancelBtn = await screen.findByRole('button', { name: /cancelar/i })
+    fireEvent.click(cancelBtn)
+    expect(deleteNodeSpy).not.toHaveBeenCalled()
   })
 
-  it('S8: clicking "Eliminar sede y sus equipos" calls deleteNode with the site group id', () => {
+  it('S8: clicking "Eliminar sede..." opens modal, confirm calls deleteNode with site id', async () => {
     const deleteNodeSpy = vi.fn()
     act(() => {
       useGraphStore.setState({
@@ -141,12 +175,57 @@ describe('PropertiesPanel delete', () => {
         selectedNodeId: 'site-1',
         selectedEdgeId: null,
         deleteNode: deleteNodeSpy,
+        markSaved: vi.fn(),
       } as any)
     })
 
     render(<PropertiesPanel />)
-    const btn = screen.getByRole('button', { name: /eliminar sede/i })
-    fireEvent.click(btn)
-    expect(deleteNodeSpy).toHaveBeenCalledWith('site-1')
+    fireEvent.click(screen.getByRole('button', { name: /eliminar sede/i }))
+    expect(deleteNodeSpy).not.toHaveBeenCalled()
+
+    const confirmBtn = await screen.findByRole('button', { name: /sí, eliminar/i })
+    fireEvent.click(confirmBtn)
+    await waitFor(() => expect(deleteNodeSpy).toHaveBeenCalledWith('site-1'))
+  })
+})
+
+describe('PropertiesPanel auto-save on delete', () => {
+  beforeEach(() => {
+    mockSaveGraph.mockClear()
+    useGraphStore.setState({
+      nodes: [], edges: [],
+      selectedNodeId: null, selectedEdgeId: null,
+      isDirty: false,
+    } as any)
+  })
+
+  it('S9: confirming "Eliminar nodo" calls saveGraph automatically', async () => {
+    const NODE = { id: 'n1', type: 'coreInternal', position: { x: 0, y: 0 }, data: { label: 'Core INT' } }
+    act(() => {
+      useGraphStore.setState({
+        nodes: [NODE as any], edges: [],
+        selectedNodeId: 'n1', selectedEdgeId: null,
+      } as any)
+    })
+    render(<PropertiesPanel />)
+    fireEvent.click(screen.getByRole('button', { name: /eliminar nodo/i }))
+    const confirmBtn = await screen.findByRole('button', { name: /sí, eliminar/i })
+    fireEvent.click(confirmBtn)
+    await waitFor(() => expect(mockSaveGraph).toHaveBeenCalledTimes(1))
+  })
+
+  it('S10: confirming "Eliminar sede..." calls saveGraph automatically', async () => {
+    const SITE = { id: 'site-1', type: 'siteGroup', position: { x: 0, y: 0 }, data: { label: 'Sede', wan_type: 'mpls' } }
+    act(() => {
+      useGraphStore.setState({
+        nodes: [SITE as any], edges: [],
+        selectedNodeId: 'site-1', selectedEdgeId: null,
+      } as any)
+    })
+    render(<PropertiesPanel />)
+    fireEvent.click(screen.getByRole('button', { name: /eliminar sede/i }))
+    const confirmBtn = await screen.findByRole('button', { name: /sí, eliminar/i })
+    fireEvent.click(confirmBtn)
+    await waitFor(() => expect(mockSaveGraph).toHaveBeenCalledTimes(1))
   })
 })

--- a/frontend/src/test/stores/useGraphStore.test.ts
+++ b/frontend/src/test/stores/useGraphStore.test.ts
@@ -4,7 +4,7 @@ import { useGraphStore } from '../../hooks/useGraphStore'
 
 describe('useGraphStore', () => {
   beforeEach(() => {
-    useGraphStore.setState({ nodes: [], edges: [], selectedNodeId: null, selectedEdgeId: null })
+    useGraphStore.setState({ nodes: [], edges: [], selectedNodeId: null, selectedEdgeId: null, isDirty: false })
   })
 
   it('addNode adds a node to the store', () => {
@@ -84,5 +84,44 @@ describe('useGraphStore', () => {
       useGraphStore.getState().updateEdge('e1', { type: 'aviat' })
     })
     expect(useGraphStore.getState().edges[1].type).toBe('mpls')
+  })
+
+  // isDirty lifecycle
+  it('S4a: isDirty starts as false', () => {
+    expect(useGraphStore.getState().isDirty).toBe(false)
+  })
+
+  it('S4b: addNode sets isDirty to true', () => {
+    const node = { id: 'n1', type: 'coreInternal', position: { x: 0, y: 0 }, data: {} }
+    act(() => useGraphStore.getState().addNode(node))
+    expect(useGraphStore.getState().isDirty).toBe(true)
+  })
+
+  it('S4b: deleteNode sets isDirty to true', () => {
+    const node = { id: 'n1', type: 'coreInternal', position: { x: 0, y: 0 }, data: {} }
+    act(() => {
+      useGraphStore.setState({ nodes: [node] })
+      useGraphStore.getState().deleteNode('n1')
+    })
+    expect(useGraphStore.getState().isDirty).toBe(true)
+  })
+
+  it('S4b: updateNodeData sets isDirty to true', () => {
+    const node = { id: 'n1', type: 'coreInternal', position: { x: 0, y: 0 }, data: { label: 'A' } }
+    act(() => {
+      useGraphStore.setState({ nodes: [node] })
+      useGraphStore.getState().updateNodeData('n1', { label: 'B' })
+    })
+    expect(useGraphStore.getState().isDirty).toBe(true)
+  })
+
+  it('S4c: markSaved resets isDirty to false', () => {
+    const node = { id: 'n1', type: 'coreInternal', position: { x: 0, y: 0 }, data: {} }
+    act(() => {
+      useGraphStore.getState().addNode(node)
+      expect(useGraphStore.getState().isDirty).toBe(true)
+      useGraphStore.getState().markSaved()
+    })
+    expect(useGraphStore.getState().isDirty).toBe(false)
   })
 })

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -3,6 +3,11 @@ export interface SiteSchema {
   name: string;
   role: string;
   wan_type: string;
+  observable_boundary: string | null;
+  canvas_x: number | null;
+  canvas_y: number | null;
+  canvas_w: number | null;
+  canvas_h: number | null;
 }
 
 export interface NetworkNodeSchema {


### PR DESCRIPTION
Closes #8

## Type
- [x] Bug fix

## Summary
- Node and site deletions were only updating ReactFlow state but not persisting to the PostgreSQL backend, causing deleted elements to reappear after page refresh.
- Implemented auto-save on delete and a confirmation modal to prevent accidental deletions.
- Fixed the backend upsert_topology endpoint to use a replace strategy (delete orphans not in payload).

## Changes

| File | Change |
|------|--------|
| rontend/src/hooks/useGraphStore.ts | Added isDirty flag and markSaved() action; all mutations set isDirty=true |
| rontend/src/api/graph.ts | Extracted uildSavePayload() pure function to share between save flows |
| rontend/src/components/GraphBuilder/GraphCanvas.tsx | Integrated uildSavePayload, added eforeunload warning, dirty badge indicator |
| rontend/src/components/GraphBuilder/PropertiesPanel.tsx | Auto-save after deleteNode; confirmation modal via createPortal |
| rontend/src/types/api.ts | Added missing canvas_x/y/w/h and observable_boundary fields to SiteSchema |
| ackend/routers/graph.py | Replace strategy in upsert_topology: delete DB rows not present in payload |
| rontend/src/test/stores/useGraphStore.test.ts | Tests S4a/b/c — isDirty lifecycle |
| rontend/src/test/components/PropertiesPanel.test.tsx | Tests S7/7b/8 (modal flow) + S9/S10 (auto-save on confirm), updated for portal |
| rontend/src/test/components/GraphCanvas.serialization.test.tsx | Fixed mock to include uildSavePayload via importOriginal |

## Test Plan
- [x] 60/60 Vitest tests passing
- [x] TypeScript: 	sc --noEmit exits with 0 errors
- [x] Manually tested: delete node → modal appears → confirm → node gone after F5
- [x] Manually tested: delete node → cancel → node persists
- [x] Verified auto-save POST fires automatically without clicking Guardar